### PR TITLE
[FIX] .env에서 설정한 'MODEL_NGROK_URL'이 매번 업데이트되도록 클래스 내 로컬 변수로 설정함.

### DIFF
--- a/models/koalpha_loader.py
+++ b/models/koalpha_loader.py
@@ -4,8 +4,8 @@ import os, time
 
 class KoalphaLoader:
     def __init__(self):
-        load_dotenv()
-        self.url = f"{os.getenv('MODEL_NGROK_URL')}/v1/chat/completions" #FastAPI와 Colab에서 열은 ngrok과 충돌나지 않게 변수명 변경
+        # load_dotenv()
+        # self.url = f"{os.getenv('MODEL_NGROK_URL')}/v1/chat/completions" #FastAPI와 Colab에서 열은 ngrok과 충돌나지 않게 변수명 변경
         self.headers = {
                             "Content-Type": "application/json",
                             "Authorization": "Bearer dummy-key"  # dummy-key: 아무거나 넣어도 됨
@@ -31,10 +31,17 @@ class KoalphaLoader:
                         {"role": "user", "content": "[Bob] 좀비 나오는 거 아냐? 난 좀비 별로인데..."},
                     ]
         '''
+        # 요청 시마다 .env를 로드하여 최신 URL 반영
+        load_dotenv(override=True)
+        base_url = os.getenv('MODEL_NGROK_URL')
+
         self.data["messages"] = messages
 
+        # 여기서 URL을 로컬 변수로만 사용
+        url = f"{base_url}/v1/chat/completions"
+
         start_time = time.time()
-        response = requests.post(self.url, headers=self.headers, json=self.data)
+        response = requests.post(url, headers=self.headers, json=self.data)
         end_time = time.time()
         print(f"response time : {(end_time - start_time):.3f}")
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #60 

## 📌 개요
- fastapi로 swagger ui 열어서 통신하면 404 에러 발생.
- response를 여니 `ERR_NGROK_3200` 발생 -> ngrok으로 통신 불가능(터널 안열림)
- 위에 'url'을 확인해보니 예전에 사용하던 url. 즉 .env에서 설정한 'MODEL_NGROK_URL'이 업데이트 되지 않음.

## 해결방법 
- 클래스에서 init으로 한번만 설정해주던 self.url을 get_response 함수에서 존재하는 로컬 변수로 바꿔서 매번 호출하게 함.
- load_dotenv()를 load_dotenv(override=True)으로 변경하여 매번 오버라이드 하게함.

## 🔁 변경 사항
1df4dfc39012551b323a1c8c171c52878eef9b49

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.