### PR TITLE
[REFACTOR] LoRA 어댑터 로깅 개선 및 get_response 로그 표기 통일

### DIFF
--- a/services/bot_posts_service.py
+++ b/services/bot_posts_service.py
@@ -138,7 +138,7 @@ class BotPostsService:
             # Generation 시작 시간
             start_time = datetime.now()
             model_response = self.model.get_response(
-                messages, trace=node_span, start_time=start_time, prompt=prompt_client, name="generate_bot_post", adapter_type="social_bot"
+                messages, trace=node_span, start_time=start_time, prompt=prompt_client, name="generate_bot_post", adapter_type="social_bot", endpoint_info="sns_posts"
             )
             end_time = datetime.now()
 

--- a/services/bot_recomments_service.py
+++ b/services/bot_recomments_service.py
@@ -146,7 +146,7 @@ class BotRecommentsService:
             # Generation 시작 시간
             start_time = datetime.now()
             model_response = self.model.get_response(
-                messages, trace=node_span, start_time=start_time, prompt=prompt_client, name="generate_bot_recomment", adapter_type="social_bot"
+                messages, trace=node_span, start_time=start_time, prompt=prompt_client, name="generate_bot_recomment", adapter_type="social_bot", endpoint_info="sns_recomments"
             )
             end_time = datetime.now()
 


### PR DESCRIPTION
- ModelLoader 및 모든 하위 모델 로더의 `get_response` 함수에 `endpoint_info` 파라미터를 추가하여, LoRA 어댑터 사용 로그에 호출 엔드포인트(sns_chat, sns_posts, sns_recomments)를 명시적으로 기록하도록 개선
- 모든 서비스(chats, posts, recomments)에서 `get_response` 호출 시 `endpoint_info`를 전달하도록 수정
- SSE 메시지 전송 전후에 상세 로그를 추가하여 디버깅 편의성 향상
- 채팅 서비스에서 SSE 메시지의 타임스탬프가 한국 시간(KST)으로 표시되도록 수정

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #

## 📌 개요
- 

## 🔁 변경 사항

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.